### PR TITLE
[Improvement] WelcomeViewController paging

### DIFF
--- a/thenews/Controllers/WelcomeViewController/TNWelcomeViewController.m
+++ b/thenews/Controllers/WelcomeViewController/TNWelcomeViewController.m
@@ -169,8 +169,14 @@
 
 #pragma mark - UIPageViewControllerDelegate Methods
 
+- (void) pageViewController:(UIPageViewController *)pageViewController willTransitionToViewControllers:(NSArray *)pendingViewControllers {
+	// Hide the page control when we're changing classes (and thus changing background colors)
+	if (! [[pendingViewControllers firstObject] isKindOfClass:[[[pageViewController viewControllers] firstObject] class]]) self.pageControl.hidden = YES;
+}
+
 - (void)pageViewController:(UIPageViewController *)pageViewController didFinishAnimating:(BOOL)finished previousViewControllers:(NSArray *)previousViewControllers transitionCompleted:(BOOL)completed
 {
+	self.pageControl.hidden = NO;
 	[self fixPageControlForViewController];
 }
 
@@ -207,16 +213,27 @@
 
 - (void)fixPageControlForViewController
 {
+	UIColor *currentTintColor = nil;
+	UIColor *otherTintColor = nil;
+	
 	// since iOS 6 `[[self.pageViewController viewControllers] firstObject]` should be the current VC
 	// see: http://stackoverflow.com/questions/8400870/uipageviewcontroller-return-the-current-visible-view
-    if ([[[self.pageViewController viewControllers] firstObject] isKindOfClass:[TNLaunchViewController class]]) {
-        self.pageControl.currentPageIndicatorTintColor = [UIColor whiteColor];
-        self.pageControl.pageIndicatorTintColor  = [[UIColor whiteColor] colorWithAlphaComponent:0.5];
-    }
+	if ([[[self.pageViewController viewControllers] firstObject] isKindOfClass:[TNLaunchViewController class]]) {
+		currentTintColor = [UIColor whiteColor];
+		otherTintColor = [[UIColor whiteColor] colorWithAlphaComponent:0.5];
+	}
 	else {
-        self.pageControl.currentPageIndicatorTintColor = [UIColor tnColor];
-        self.pageControl.pageIndicatorTintColor  = [UIColor tnGreyColor];
-    }
+		currentTintColor = [UIColor tnColor];
+		otherTintColor = [UIColor tnGreyColor];
+	}
+	
+	// No need to re-animate the same color...
+	if ([self.pageControl.currentPageIndicatorTintColor isEqual:currentTintColor]) return;
+	
+	[UIView animateWithDuration:0.25 animations:^{
+		self.pageControl.currentPageIndicatorTintColor = currentTintColor;
+		self.pageControl.pageIndicatorTintColor = otherTintColor;
+	}];
 }
 
 @end

--- a/thenews/Controllers/WelcomeViewController/TNWelcomeViewController.m
+++ b/thenews/Controllers/WelcomeViewController/TNWelcomeViewController.m
@@ -169,20 +169,9 @@
 
 #pragma mark - UIPageViewControllerDelegate Methods
 
-- (void)pageViewController:(UIPageViewController *)pageViewController willTransitionToViewControllers:(NSArray *)pendingViewControllers 
-{
-    UIViewController *vc = [pendingViewControllers firstObject];
-    [self fixPageControlForViewController:vc];
-}
-
 - (void)pageViewController:(UIPageViewController *)pageViewController didFinishAnimating:(BOOL)finished previousViewControllers:(NSArray *)previousViewControllers transitionCompleted:(BOOL)completed
 {
-    if (completed) {
-        return;
-    }
-
-    UIViewController *vc = [previousViewControllers firstObject];
-    [self fixPageControlForViewController:vc];
+	[self fixPageControlForViewController];
 }
 
 #pragma mark - Button Actions
@@ -216,15 +205,15 @@
     return button;
 }
 
-- (void)fixPageControlForViewController:(UIViewController *)vc
+- (void)fixPageControlForViewController
 {
-    if ([vc isKindOfClass:[TNLaunchViewController class]]) {
-
+	// since iOS 6 `[[self.pageViewController viewControllers] firstObject]` should be the current VC
+	// see: http://stackoverflow.com/questions/8400870/uipageviewcontroller-return-the-current-visible-view
+    if ([[[self.pageViewController viewControllers] firstObject] isKindOfClass:[TNLaunchViewController class]]) {
         self.pageControl.currentPageIndicatorTintColor = [UIColor whiteColor];
         self.pageControl.pageIndicatorTintColor  = [[UIColor whiteColor] colorWithAlphaComponent:0.5];
-
-    } else {
-
+    }
+	else {
         self.pageControl.currentPageIndicatorTintColor = [UIColor tnColor];
         self.pageControl.pageIndicatorTintColor  = [UIColor tnGreyColor];
     }


### PR DESCRIPTION
When sliding from page 1 to page 2, the PageControl will be white on white; when going 2 -> 1, it will be grey on green. Let's hide it when starting those transitions, then animate it back into view. Nice.